### PR TITLE
Use `tidytable::enframe()`

### DIFF
--- a/R/journalabbr-package.R
+++ b/R/journalabbr-package.R
@@ -26,6 +26,6 @@
 #' @importFrom stringr str_squish
 #' @importFrom stringr str_to_upper
 #' @importFrom tidytable as_tidytable
-#' @importFrom tidytable enframe.
+#' @importFrom tidytable enframe
 ## usethis namespace: end
 NULL

--- a/R/read_bib2dt.R
+++ b/R/read_bib2dt.R
@@ -72,7 +72,7 @@ read_bib2dt <- function(file) {
     return(bib[x:y])
   }, x = from, y = to - 1, SIMPLIFY = FALSE)
 
-  dt <- tidytable::enframe.(itemslist, name = "fz_id", value = "fz_rawchar")
+  dt <- tidytable::enframe(itemslist, name = "fz_id", value = "fz_rawchar")
 
   dt$fz_char <- NA
   dt$fz_char <- map(dt$fz_rawchar, function(x) {

--- a/devtools_history.R
+++ b/devtools_history.R
@@ -42,7 +42,7 @@ use_import_from("purrr",'map2')
 use_import_from("purrr",'map_chr')
 
 use_import_from("tidytable",'as_tidytable')
-use_import_from("tidytable",'enframe.')
+use_import_from("tidytable",'enframe')
 
 use_import_from("data.table",'fread')
 use_import_from("data.table",'as.data.table')


### PR DESCRIPTION
Hello - I am looking to release a new version of `tidytable` in the next couple weeks. `enframe.()` is going to be deprecated and replaced with `enframe()`. This pull request updates the usage in your package.

If you could please merge this pull request and submit a new version of `journalabbr` to CRAN I would appreciate it.